### PR TITLE
Implement libfmt example

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,3 +35,26 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
 
+  build-with-fmtlib:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DRTLOG_USE_FMTLIB=ON
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ if(NOT TARGET readerwriterqueue)
     FetchContent_MakeAvailable(ReaderWriterQueue)
 endif()
 
-if(NOT TARGET stb)
+if(NOT TARGET stb::stb)
     # Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
     if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
         cmake_policy(SET CMP0135 NEW)
@@ -60,15 +60,26 @@ if(NOT TARGET stb)
     )
 endif()
 
+if (RTLOG_USE_FMTLIB AND NOT TARGET fmt::fmt)
+    include(FetchContent)
+
+    FetchContent_Declare(fmtlib
+        GIT_REPOSITORY https://github.com/fmtlib/fmt 
+    )
+    FetchContent_MakeAvailable(fmtlib)
+endif()
+
 target_link_libraries(rtlog 
     INTERFACE 
         readerwriterqueue
         stb::stb
+        $<$<BOOL:${RTLOG_USE_FMTLIB}>:fmt::fmt>
 )
 
 target_compile_definitions(rtlog 
     INTERFACE 
         STB_SPRINTF_IMPLEMENTATION 
+        $<$<BOOL:${RTLOG_USE_FMTLIB}>:RTLOG_USE_FMTLIB>
         $<$<CONFIG:Debug>:DEBUG>
         $<$<CONFIG:Release>:NDEBUG>
 )

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-My License:
+# My License:
 This license applies to all code in this repo, except for third party libraries. If you use this code in your project, please send me an email and tell me! I'd love to hear about it being used :)
 
 The MIT License (MIT)
@@ -24,7 +24,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-ReaderWriterQueue license:
+# ReaderWriterQueue license:
 This license applies to all the code in this repository except that written by third parties, namely the files in benchmarks/ext, which have their own licenses, and Jeff Preshing's semaphore implementation (used in the blocking queues) which has a zlib license (embedded in atomicops.h).
 
 Simplified BSD License:
@@ -40,7 +40,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-Doctest license:
+# Doctest license:
 The MIT License (MIT)
 
 Copyright (c) 2016-2023 Viktor Kirilov
@@ -62,3 +62,72 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+# Libfmt license:
+Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--- Optional exception to the license ---
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into a machine-executable object form of such
+source code, you may redistribute such embedded portions in such object form
+without including the above copyright and permission notices.
+
+STB:
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ target_link_libraries(audioapp
  )
 ```
 
+To use formatlib, set the variable, either on the command line or in cmake:
+```bash
+cmake .. -DRTLOG_USE_FMTLIB=ON
+```
+
 ## Usage
 
 For more fleshed out fully running examples check out `examples/` and `test/`

--- a/examples/everlog/everlogmain.cpp
+++ b/examples/everlog/everlogmain.cpp
@@ -134,6 +134,13 @@ static rtlog::Logger<LogData, MAX_NUM_LOG_MESSAGES, MAX_LOG_MESSAGE_LENGTH, gSeq
 #define EVR_LOG_WARNING(Region, fstring, ...) PrintMessage({ LogLevel::Warning, Region}, ++gSequenceNumber, fstring, ##__VA_ARGS__)
 #define EVR_LOG_CRITICAL(Region, ...) PrintMessage({ LogLevel::Critical, Region}, ++gSequenceNumber, fstring, ##__VA_ARGS__)
 
+#define EVR_RTLOG_DEBUG(Region, fstring, ...) gRealtimeLogger.Log({ LogLevel::Debug, Region}, fstring, ##__VA_ARGS__)
+#define EVR_RTLOG_INFO(Region, fstring, ...) gRealtimeLogger.Log({ LogLevel::Info, Region}, fstring, ##__VA_ARGS__)
+#define EVR_RTLOG_WARNING(Region, fstring, ...) gRealtimeLogger.Log({ LogLevel::Warning, Region}, fstring, ##__VA_ARGS__)
+#define EVR_RTLOG_CRITICAL(Region, fstring, ...) gRealtimeLogger.Log({ LogLevel::Critical, Region}, fstring, ##__VA_ARGS__)
+
+
+
 #ifdef RTLOG_USE_FMTLIB
 
 #define EVR_RTLOG_FMT_DEBUG(Region, fstring, ...) gRealtimeLogger.LogFmt({ LogLevel::Debug, Region}, FMT_STRING(fstring), ##__VA_ARGS__)
@@ -142,17 +149,14 @@ static rtlog::Logger<LogData, MAX_NUM_LOG_MESSAGES, MAX_LOG_MESSAGE_LENGTH, gSeq
 #define EVR_RTLOG_FMT_CRITICAL(Region, fstring, ...) gRealtimeLogger.LogFmt({ LogLevel::Critical, Region}, FMT_STRING(fstring), ##__VA_ARGS__)
 
 #else
+
 // define the above macros as no-ops
 #define EVR_RTLOG_FMT_DEBUG(Region, fstring, ...) (void)0
 #define EVR_RTLOG_FMT_INFO(Region, fstring, ...) (void)0
 #define EVR_RTLOG_FMT_WARNING(Region, fstring, ...) (void)0
 #define EVR_RTLOG_FMT_CRITICAL(Region, fstring, ...) (void)0
-#endif
 
-#define EVR_RTLOG_DEBUG(Region, fstring, ...) gRealtimeLogger.Log({ LogLevel::Debug, Region}, fstring, ##__VA_ARGS__)
-#define EVR_RTLOG_INFO(Region, fstring, ...) gRealtimeLogger.Log({ LogLevel::Info, Region}, fstring, ##__VA_ARGS__)
-#define EVR_RTLOG_WARNING(Region, fstring, ...) gRealtimeLogger.Log({ LogLevel::Warning, Region}, fstring, ##__VA_ARGS__)
-#define EVR_RTLOG_CRITICAL(Region, fstring, ...) gRealtimeLogger.Log({ LogLevel::Critical, Region}, fstring, ##__VA_ARGS__)
+#endif // RTLOG_USE_FMTLIB
 
 int main(int argc, char** argv)
 {

--- a/examples/everlog/everlogmain.cpp
+++ b/examples/everlog/everlogmain.cpp
@@ -129,15 +129,30 @@ std::atomic<bool> gRunning{ true };
 std::atomic<std::size_t> gSequenceNumber{ 0 };
 static rtlog::Logger<LogData, MAX_NUM_LOG_MESSAGES, MAX_LOG_MESSAGE_LENGTH, gSequenceNumber> gRealtimeLogger;
 
-#define EVR_LOG_DEBUG(Region, ...) PrintMessage({ LogLevel::Debug, Region}, ++gSequenceNumber, __VA_ARGS__)
-#define EVR_LOG_INFO(Region, ...) PrintMessage({ LogLevel::Info, Region}, ++gSequenceNumber, __VA_ARGS__)
-#define EVR_LOG_WARNING(Region, ...) PrintMessage({ LogLevel::Warning, Region}, ++gSequenceNumber, __VA_ARGS__)
-#define EVR_LOG_CRITICAL(Region, ...) PrintMessage({ LogLevel::Critical, Region}, ++gSequenceNumber, __VA_ARGS__)
+#define EVR_LOG_DEBUG(Region, fstring, ...) PrintMessage({ LogLevel::Debug, Region}, ++gSequenceNumber, fstring, ##__VA_ARGS__)
+#define EVR_LOG_INFO(Region, fstring, ...) PrintMessage({ LogLevel::Info, Region}, ++gSequenceNumber, fstring, ##__VA_ARGS__)
+#define EVR_LOG_WARNING(Region, fstring, ...) PrintMessage({ LogLevel::Warning, Region}, ++gSequenceNumber, fstring, ##__VA_ARGS__)
+#define EVR_LOG_CRITICAL(Region, ...) PrintMessage({ LogLevel::Critical, Region}, ++gSequenceNumber, fstring, ##__VA_ARGS__)
 
-#define EVR_RTLOG_DEBUG(Region, ...) gRealtimeLogger.Log({ LogLevel::Debug, Region}, __VA_ARGS__)
-#define EVR_RTLOG_INFO(Region, ...) gRealtimeLogger.Log({ LogLevel::Info, Region}, __VA_ARGS__)
-#define EVR_RTLOG_WARNING(Region, ...) gRealtimeLogger.Log({ LogLevel::Warning, Region}, __VA_ARGS__)
-#define EVR_RTLOG_CRITICAL(Region, ...) gRealtimeLogger.Log({ LogLevel::Critical, Region}, __VA_ARGS__)
+#ifdef RTLOG_USE_FMTLIB
+
+#define EVR_RTLOG_FMT_DEBUG(Region, fstring, ...) gRealtimeLogger.LogFmt({ LogLevel::Debug, Region}, FMT_STRING(fstring), ##__VA_ARGS__)
+#define EVR_RTLOG_FMT_INFO(Region, fstring, ...) gRealtimeLogger.LogFmt({ LogLevel::Info, Region}, FMT_STRING(fstring), ##__VA_ARGS__)
+#define EVR_RTLOG_FMT_WARNING(Region, fstring, ...) gRealtimeLogger.LogFmt({ LogLevel::Warning, Region}, FMT_STRING(fstring), ##__VA_ARGS__)
+#define EVR_RTLOG_FMT_CRITICAL(Region, fstring, ...) gRealtimeLogger.LogFmt({ LogLevel::Critical, Region}, FMT_STRING(fstring), ##__VA_ARGS__)
+
+#else
+// define the above macros as no-ops
+#define EVR_RTLOG_FMT_DEBUG(Region, fstring, ...) (void)0
+#define EVR_RTLOG_FMT_INFO(Region, fstring, ...) (void)0
+#define EVR_RTLOG_FMT_WARNING(Region, fstring, ...) (void)0
+#define EVR_RTLOG_FMT_CRITICAL(Region, fstring, ...) (void)0
+#endif
+
+#define EVR_RTLOG_DEBUG(Region, fstring, ...) gRealtimeLogger.Log({ LogLevel::Debug, Region}, fstring, ##__VA_ARGS__)
+#define EVR_RTLOG_INFO(Region, fstring, ...) gRealtimeLogger.Log({ LogLevel::Info, Region}, fstring, ##__VA_ARGS__)
+#define EVR_RTLOG_WARNING(Region, fstring, ...) gRealtimeLogger.Log({ LogLevel::Warning, Region}, fstring, ##__VA_ARGS__)
+#define EVR_RTLOG_CRITICAL(Region, fstring, ...) gRealtimeLogger.Log({ LogLevel::Critical, Region}, fstring, ##__VA_ARGS__)
 
 int main(int argc, char** argv)
 {
@@ -151,6 +166,7 @@ int main(int argc, char** argv)
             for (int i = 99; i >= 0; i--)
             {
                 EVR_RTLOG_DEBUG(LogRegion::Audio, "Hello %d from rt-thread", i);
+                EVR_RTLOG_FMT_WARNING(LogRegion::Audio, "Hello {} from rt-thread - logging with {}", i, "libfmt");
                 RealtimeBusyWait(10, gRealtimeLogger);
             }
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,8 +1,10 @@
-include(FetchContent)
-FetchContent_Declare(doctest
-  GIT_REPOSITORY https://github.com/doctest/doctest
-)
-FetchContent_MakeAvailable(doctest)
+if (NOT TARGET doctest::doctest)
+    include(FetchContent)
+    FetchContent_Declare(doctest
+      GIT_REPOSITORY https://github.com/doctest/doctest
+    )
+    FetchContent_MakeAvailable(doctest)
+endif()
 
 # These two are painfully not easily accessed. 
 # TODO: CAPPLE submitted a PR that got accepted into doctest, switch to that newer version when we can
@@ -25,7 +27,7 @@ target_link_libraries(rtlog_tests
 
 set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED ON)
 
-if (CMAKE_GENERATOR STREQUAL "Xcode" OR NOT APPLE)
+if (CMAKE_GENERATOR STREQUAL "Xcode")
     add_test(NAME rtlog_tests COMMAND rtlog_tests)
 else()
     doctest_discover_tests(rtlog_tests)


### PR DESCRIPTION
Libfmt is great. It [doesn't allocate ](https://github.com/fmtlib/fmt/issues/1665) using `format_to_n`. It also uses variadic templates when are guaranteed to not allocate at runtime.

Create a secondary method to print to the logs using libfmt.