### PR TITLE
Fix compile error when calling LogFmt with rvalue args

### DIFF
--- a/include/rtlog/rtlog.h
+++ b/include/rtlog/rtlog.h
@@ -139,7 +139,7 @@ public:
 
         const auto maxMessageLength = dataToQueue.mMessage.size() - 1; // Account for null terminator
 
-        const auto result = fmt::format_to_n(dataToQueue.mMessage.data(), maxMessageLength, fmtString, args...);
+        const auto result = fmt::format_to_n(dataToQueue.mMessage.data(), maxMessageLength, fmtString, std::forward<T>(args)...);
 
         if (result.size >= dataToQueue.mMessage.size())
         {


### PR DESCRIPTION
Hi again!
I've been wrestling with some compile errors when using C++20 and Clang on Windows. Whenever calling `LogFmt` with an rvalue, e.g. like these:

```c++
gRealtimeLogger.LogFmt (LogRegion::Audio, "Here's a number: ", 42);

struct MyClass
{
    int getSomeNumber() const { return 42; }
};
MyClass myClass;

gRealtimeLogger.LogFmt (LogRegion::Audio, "Here's a number: ", myClass.getSomeNumber());
``` 
.. I would get an error message like this one:
```
error: call to consteval function 'fmt::basic_format_string<char, int &>::basic_format_string<fmt::basic_format_string<char, int>, 0>' is not a constant expression
        const auto result = fmt::format_to_n(dataToQueue.mMessage.data(), maxMessageLength, fmtString, args...);
``` 
Looks like it can be solved by simply adding a `std::forward` in the `LogFmt` method.