### PR TITLE
build fix for MSVC compilation.

### DIFF
--- a/include/rtlog/rtlog.h
+++ b/include/rtlog/rtlog.h
@@ -131,7 +131,10 @@ public:
    * `Status::Error_MessageTruncated`. Otherwise, it returns `Status::Success`.
    */
   Status Log(LogData &&inputData, const char *format, ...)
-      __attribute__((format(printf, 3, 4))) {
+#ifndef __MSC_VER__
+      __attribute__((format(printf, 3, 4)))
+#endif
+  {
     va_list args;
     va_start(args, format);
     auto retVal = Logv(std::move(inputData), format, args);


### PR DESCRIPTION
I tried to use rtlog-cpp on Windows sing VC++, but it does not like GCC extension attributes. If I understand correctly, `format` does not affect run-time behavior, so I simply took it out for VC++.

(I'm not sure how clang-format likes this change, on CLion it does not auto format like current code file. I leave it as is. Excuse me of that.)