### PR TITLE
Make libfmt or stb either/or, change libfmt `LogFmt` to just be `Log`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ if(NOT TARGET readerwriterqueue)
     FetchContent_MakeAvailable(ReaderWriterQueue)
 endif()
 
-if(NOT TARGET stb::stb)
+if(NOT RTSAN_USE_FMTLIB AND NOT TARGET stb::stb)
     # Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
     if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
         cmake_policy(SET CMP0135 NEW)
@@ -98,6 +98,7 @@ target_compile_definitions(rtlog
     INTERFACE 
         STB_SPRINTF_IMPLEMENTATION 
         $<$<BOOL:${RTLOG_USE_FMTLIB}>:RTLOG_USE_FMTLIB>
+        $<$<NOT:$<BOOL:${RTLOG_USE_FMTLIB}>>:RTLOG_USE_STB>
         $<$<CONFIG:Debug>:DEBUG>
         $<$<CONFIG:Release>:NDEBUG>
 )

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ RealtimeLogger logger;
 void SomeRealtimeCallback()
 {
     logger.Log({ExampleLogLevel::Debug, ExampleLogRegion::Audio}, "Hello, world! %i", 42);
-    logger.LogFmt({ExampleLogData::Debug, ExampleLogRegion::Audio, FMT_STRING("Hello, world! {}", 42);
+
+    // using RTSAN_USE_LIBFMT
+    logger.Log({ExampleLogData::Debug, ExampleLogRegion::Audio, FMT_STRING("Hello, world! {}", 42);
 }
 
 ...

--- a/examples/everlog/everlogmain.cpp
+++ b/examples/everlog/everlogmain.cpp
@@ -121,6 +121,7 @@ static rtlog::Logger<LogData, MAX_NUM_LOG_MESSAGES, MAX_LOG_MESSAGE_LENGTH,
   PrintMessage({LogLevel::Critical, Region}, ++gSequenceNumber, fstring,       \
                ##__VA_ARGS__)
 
+#ifdef RTLOG_USE_STB
 #define EVR_RTLOG_DEBUG(Region, fstring, ...)                                  \
   gRealtimeLogger.Log({LogLevel::Debug, Region}, fstring, ##__VA_ARGS__)
 #define EVR_RTLOG_INFO(Region, fstring, ...)                                   \
@@ -129,21 +130,27 @@ static rtlog::Logger<LogData, MAX_NUM_LOG_MESSAGES, MAX_LOG_MESSAGE_LENGTH,
   gRealtimeLogger.Log({LogLevel::Warning, Region}, fstring, ##__VA_ARGS__)
 #define EVR_RTLOG_CRITICAL(Region, fstring, ...)                               \
   gRealtimeLogger.Log({LogLevel::Critical, Region}, fstring, ##__VA_ARGS__)
+#else
+#define EVR_RTLOG_DEBUG(Region, fstring, ...) (void)0
+#define EVR_RTLOG_INFO(Region, fstring, ...) (void)0
+#define EVR_RTLOG_WARNING(Region, fstring, ...) (void)0
+#define EVR_RTLOG_CRITICAL(Region, fstring, ...) (void)0
+#endif // RTLOG_USE_STB
 
 #ifdef RTLOG_USE_FMTLIB
 
 #define EVR_RTLOG_FMT_DEBUG(Region, fstring, ...)                              \
-  gRealtimeLogger.LogFmt({LogLevel::Debug, Region}, FMT_STRING(fstring),       \
-                         ##__VA_ARGS__)
+  gRealtimeLogger.Log({LogLevel::Debug, Region}, FMT_STRING(fstring),          \
+                      ##__VA_ARGS__)
 #define EVR_RTLOG_FMT_INFO(Region, fstring, ...)                               \
-  gRealtimeLogger.LogFmt({LogLevel::Info, Region}, FMT_STRING(fstring),        \
-                         ##__VA_ARGS__)
+  gRealtimeLogger.Log({LogLevel::Info, Region}, FMT_STRING(fstring),           \
+                      ##__VA_ARGS__)
 #define EVR_RTLOG_FMT_WARNING(Region, fstring, ...)                            \
-  gRealtimeLogger.LogFmt({LogLevel::Warning, Region}, FMT_STRING(fstring),     \
-                         ##__VA_ARGS__)
+  gRealtimeLogger.Log({LogLevel::Warning, Region}, FMT_STRING(fstring),        \
+                      ##__VA_ARGS__)
 #define EVR_RTLOG_FMT_CRITICAL(Region, fstring, ...)                           \
-  gRealtimeLogger.LogFmt({LogLevel::Critical, Region}, FMT_STRING(fstring),    \
-                         ##__VA_ARGS__)
+  gRealtimeLogger.Log({LogLevel::Critical, Region}, FMT_STRING(fstring),       \
+                      ##__VA_ARGS__)
 
 #else
 

--- a/include/rtlog/rtlog.h
+++ b/include/rtlog/rtlog.h
@@ -6,12 +6,18 @@
 #include <cstdio>
 #include <thread>
 
+#if !defined(RTLOG_USE_FMTLIB) && !defined(RTLOG_USE_STB)
+// The default behavior to match legacy behavior is to use STB
+#define RTLOG_USE_STB
+#endif
+
 #ifdef RTLOG_USE_FMTLIB
 #include <fmt/format.h>
 #endif // RTLOG_USE_FMTLIB
 
 #include <readerwriterqueue.h>
 
+#ifdef RTLOG_USE_STB
 #ifndef STB_SPRINTF_IMPLEMENTATION
 #define STB_SPRINTF_IMPLEMENTATION
 #endif
@@ -21,6 +27,7 @@
 #endif
 
 #include <stb_sprintf.h>
+#endif // RTLOG_USE_STB
 
 #if defined(__has_feature)
 #if __has_feature(realtime_sanitizer)
@@ -96,6 +103,7 @@ public:
    * message was truncated, the function returns
    * `Status::Error_MessageTruncated`. Otherwise, it returns `Status::Success`.
    */
+#ifdef RTLOG_USE_STB
   Status Logv(LogData &&inputData, const char *format,
               va_list args) noexcept RTLOG_NONBLOCKING {
     auto retVal = Status::Success;
@@ -156,6 +164,7 @@ public:
     va_end(args);
     return retVal;
   }
+#endif // RTLOG_USE_STB
 
 #ifdef RTLOG_USE_FMTLIB
 
@@ -187,8 +196,8 @@ public:
    * `Status::Error_MessageTruncated`. Otherwise, it returns `Status::Success`.
    */
   template <typename... T>
-  Status LogFmt(LogData &&inputData, fmt::format_string<T...> fmtString,
-                T &&...args) noexcept RTLOG_NONBLOCKING {
+  Status Log(LogData &&inputData, fmt::format_string<T...> fmtString,
+             T &&...args) noexcept RTLOG_NONBLOCKING {
     auto retVal = Status::Success;
 
     InternalLogData dataToQueue;

--- a/test/test_rtlog.cpp
+++ b/test/test_rtlog.cpp
@@ -66,6 +66,8 @@ static auto PrintMessage = [](const ExampleLogData &data, size_t sequenceNumber,
 
 using namespace rtlog::test;
 
+#ifdef RTLOG_USE_STB
+
 TEST(RtlogTest, BasicConstruction) {
   rtlog::Logger<ExampleLogData, MAX_NUM_LOG_MESSAGES, MAX_LOG_MESSAGE_LENGTH,
                 gSequenceNumber>
@@ -193,6 +195,7 @@ TEST(RtlogTest, ErrorsReturnedFromLog) {
   };
   EXPECT_EQ(truncatedLogger.PrintAndClearLogQueue(InspectLogMessage), 1);
 }
+#endif // RTLOG_USE_STB
 
 #ifdef RTLOG_USE_FMTLIB
 
@@ -201,39 +204,39 @@ TEST(LoggerTest, FormatLibVersionWorksAsIntended) {
                 gSequenceNumber>
       logger;
 
-  logger.LogFmt({ExampleLogLevel::Debug, ExampleLogRegion::Engine},
-                FMT_STRING("Hello, {}!"), 123l);
-  logger.LogFmt({ExampleLogLevel::Info, ExampleLogRegion::Game},
-                FMT_STRING("Hello, {}!"), 123.0f);
-  logger.LogFmt({ExampleLogLevel::Warning, ExampleLogRegion::Network},
-                FMT_STRING("Hello, {}!"), 123.0);
-  logger.LogFmt({ExampleLogLevel::Critical, ExampleLogRegion::Audio},
-                FMT_STRING("Hello, {}!"), (void *)123);
-  logger.LogFmt({ExampleLogLevel::Debug, ExampleLogRegion::Engine},
-                FMT_STRING("Hello, {}!"), 123);
-  logger.LogFmt({ExampleLogLevel::Critical, ExampleLogRegion::Audio},
-                FMT_STRING("Hello, {}!"), "world");
+  logger.Log({ExampleLogLevel::Debug, ExampleLogRegion::Engine},
+             FMT_STRING("Hello, {}!"), 123l);
+  logger.Log({ExampleLogLevel::Info, ExampleLogRegion::Game},
+             FMT_STRING("Hello, {}!"), 123.0f);
+  logger.Log({ExampleLogLevel::Warning, ExampleLogRegion::Network},
+             FMT_STRING("Hello, {}!"), 123.0);
+  logger.Log({ExampleLogLevel::Critical, ExampleLogRegion::Audio},
+             FMT_STRING("Hello, {}!"), (void *)123);
+  logger.Log({ExampleLogLevel::Debug, ExampleLogRegion::Engine},
+             FMT_STRING("Hello, {}!"), 123);
+  logger.Log({ExampleLogLevel::Critical, ExampleLogRegion::Audio},
+             FMT_STRING("Hello, {}!"), "world");
 
   EXPECT_EQ(logger.PrintAndClearLogQueue(PrintMessage), 6);
 }
 
-TEST(LoggerTest, LogFmtReturnsSuccessOnNormalEnqueue) {
+TEST(LoggerTest, LogReturnsSuccessOnNormalEnqueue) {
   rtlog::Logger<ExampleLogData, MAX_NUM_LOG_MESSAGES, MAX_LOG_MESSAGE_LENGTH,
                 gSequenceNumber>
       logger;
-  EXPECT_EQ(logger.LogFmt({ExampleLogLevel::Debug, ExampleLogRegion::Engine},
-                          FMT_STRING("Hello, {}!"), 123l),
+  EXPECT_EQ(logger.Log({ExampleLogLevel::Debug, ExampleLogRegion::Engine},
+                       FMT_STRING("Hello, {}!"), 123l),
             rtlog::Status::Success);
 }
 
-TEST(LoggerTest, LogFmtHandlesLongMessageTruncation) {
+TEST(LoggerTest, LogHandlesLongMessageTruncation) {
   const auto maxMessageLength = 10;
   rtlog::Logger<ExampleLogData, MAX_NUM_LOG_MESSAGES, maxMessageLength,
                 gSequenceNumber>
       logger;
 
-  EXPECT_EQ(logger.LogFmt({ExampleLogLevel::Debug, ExampleLogRegion::Engine},
-                          FMT_STRING("Hello, {}! xxxxxxxxxxx"), 123l),
+  EXPECT_EQ(logger.Log({ExampleLogLevel::Debug, ExampleLogRegion::Engine},
+                       FMT_STRING("Hello, {}! xxxxxxxxxxx"), 123l),
             rtlog::Status::Error_MessageTruncated);
 
   auto InspectLogMessage = [=](const ExampleLogData &data,
@@ -257,7 +260,7 @@ TEST(LoggerTest, LogFmtHandlesLongMessageTruncation) {
   EXPECT_EQ(logger.PrintAndClearLogQueue(InspectLogMessage), 1);
 }
 
-TEST(LoggerTest, LogFmtHandlesQueueFullError) {
+TEST(LoggerTest, LogHandlesQueueFullError) {
   const auto maxNumMessages = 10;
   rtlog::Logger<ExampleLogData, maxNumMessages, MAX_LOG_MESSAGE_LENGTH,
                 gSequenceNumber>
@@ -266,8 +269,8 @@ TEST(LoggerTest, LogFmtHandlesQueueFullError) {
   auto status = rtlog::Status::Success;
 
   while (status == rtlog::Status::Success) {
-    status = logger.LogFmt({ExampleLogLevel::Debug, ExampleLogRegion::Engine},
-                           FMT_STRING("Hello, {}!"), "world");
+    status = logger.Log({ExampleLogLevel::Debug, ExampleLogRegion::Engine},
+                        FMT_STRING("Hello, {}!"), "world");
   }
 
   EXPECT_EQ(status, rtlog::Status::Error_QueueFull);


### PR DESCRIPTION
Limit the build to only supporting the stb version, or the libfmt version by default. This is in an attempt to prevent users from downloading multiple dependencies they don't use.

In addition, making a backwards incompatible change, the name of the `LogFmt` method is now just `Log`