### PR TITLE
Smaller cleanups from the swap queues change

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Test
       working-directory: build
-      run: ctest -C ${{ env.BUILD_TYPE }}
+      run: ctest -C ${{ env.BUILD_TYPE }} --timeout 10

--- a/examples/everlog/everlogmain.cpp
+++ b/examples/everlog/everlogmain.cpp
@@ -4,7 +4,7 @@
 
 namespace evr {
 constexpr auto MAX_LOG_MESSAGE_LENGTH = 256;
-constexpr auto MAX_NUM_LOG_MESSAGES = 100;
+constexpr auto MAX_NUM_LOG_MESSAGES = 128;
 
 enum class LogLevel { Debug, Info, Warning, Critical };
 


### PR DESCRIPTION
Add a timeout in case tests overrun.

In #33 there will be a requirement to have powers of two queues, get that set up for everlog.